### PR TITLE
Icons of accessories not centered in Firefox

### DIFF
--- a/src/components/accessories/brightness.vue
+++ b/src/components/accessories/brightness.vue
@@ -333,6 +333,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     color: var(--accessory-text);
                 }
             }

--- a/src/components/accessories/fan.vue
+++ b/src/components/accessories/fan.vue
@@ -437,6 +437,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     color: var(--accessory-text);
                 }
             }
@@ -490,6 +491,7 @@
 
                     .icon {
                         height: 50%;
+                        width: 50%;
                     }
                 }
             }

--- a/src/components/accessories/light.vue
+++ b/src/components/accessories/light.vue
@@ -529,6 +529,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     color: var(--accessory-text);
                 }
             }
@@ -582,6 +583,7 @@
 
                     .icon {
                         height: 50%;
+                        width: 50%;
                     }
                 }
             }

--- a/src/components/accessories/off.vue
+++ b/src/components/accessories/off.vue
@@ -91,6 +91,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     color: var(--accessory-text);
                 }
             }

--- a/src/components/accessories/sprinkler.vue
+++ b/src/components/accessories/sprinkler.vue
@@ -427,6 +427,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     color: var(--accessory-text);
                 }
             }

--- a/src/components/accessories/switch.vue
+++ b/src/components/accessories/switch.vue
@@ -253,6 +253,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     color: var(--accessory-text);
                 }
             }

--- a/src/components/accessories/television.vue
+++ b/src/components/accessories/television.vue
@@ -425,6 +425,7 @@
 
                 .icon {
                     height: 50%;
+                    width: 50%;
                     margin-bottom: 7px;
                     color: var(--accessory-text);
                 }


### PR DESCRIPTION
In Firefox (e.g.: 107.0.1) the icons of the accessories are off-centred.  
This is because .inner has no width defined and therefore a 0px wide div is being centred in the flexbox.

Due to the nature of the icons being squared, I added a width of 50% to the `.inner`.